### PR TITLE
feat: dry-run mode for ephemeral PR environments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -55,6 +55,7 @@ jobs:
                TwilioPhoneNumber=${{ vars.TWILIO_PHONE_NUMBER }} \
                DeployFrontend=false \
                EnableCron=false \
+               DryRun=true \
                CorsAllowedOrigins=*"
 
       - name: Get API URL

--- a/cron/handler.js
+++ b/cron/handler.js
@@ -63,11 +63,17 @@ exports.handler = async () => {
             continue;
           }
 
-          await makeReservation(
-            classId,
-            user.username,
-            decrypt(user.password)
-          );
+          if (process.env.DRY_RUN === "true") {
+            console.log(
+              `> [DRY RUN] Would have booked classId=${classId} time=${timeToBook} for user=${appointment.userId} — skipping real reservation`
+            );
+          } else {
+            await makeReservation(
+              classId,
+              user.username,
+              decrypt(user.password)
+            );
+          }
 
           // Update appointment as fulfilled
           await docClient.send(

--- a/template.yaml
+++ b/template.yaml
@@ -38,6 +38,11 @@ Parameters:
     Default: "true"
     AllowedValues: ["true", "false"]
     Description: Set to false to disable the scheduled cron trigger (e.g. for ephemeral PR stacks)
+  DryRun:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: Set to true to skip real bookings (logs instead). Used in ephemeral PR environments.
 
 Conditions:
   IsFrontendEnabled: !Equals [!Ref DeployFrontend, "true"]
@@ -53,6 +58,7 @@ Globals:
         APPOINTMENTS_TABLE: !Sub "${AWS::StackName}-Appointments"
         JWT_SECRET: !Ref JwtSecret
         ENCRYPTION_KEY: !Ref EncryptionKey
+        DRY_RUN: !Ref DryRun
         CORS_ALLOWED_ORIGINS: !Ref CorsAllowedOrigins
 
 Resources:


### PR DESCRIPTION
Adds a `DryRun` SAM parameter (default `false`) that prevents real bookings in ephemeral PR stacks.

## What changed
- `template.yaml` — new `DryRun` parameter, passed as `DRY_RUN` env var to all lambdas
- `cron/handler.js` — when `DRY_RUN=true`, logs what would have been booked instead of calling `makeReservation`
- `pr-preview.yml` — passes `DryRun=true` to SAM deploy for all ephemeral stacks

## Why
Prevents test activity in PR environments from making real reservations against the Embrace North API.